### PR TITLE
Revert changes in configuration.go and fix it

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -99,17 +99,11 @@ func (c *Configuration) Capture(ev *tcell.EventKey) *tcell.EventKey {
 		return nil
 	}
 
-	key := ev.Key()
-	mod := ev.Modifiers()
-
 	var keyName string
-	if key == tcell.KeyRune {
-		keyName = fmt.Sprintf("%d:%d", mod, ev.Rune())
+	if ev.Key() != tcell.KeyRune {
+		keyName = fmt.Sprintf("%d-%d", ev.Modifiers(), ev.Key())
 	} else {
-		if key == tcell.KeyBackspace || key == tcell.KeyTab || key == tcell.KeyEnter {
-			mod ^= tcell.ModCtrl
-		}
-		keyName = fmt.Sprintf("%d-%d", mod, key)
+		keyName = fmt.Sprintf("%d:%d", ev.Modifiers(), ev.Rune())
 	}
 
 	handler := c.handlers[keyName]

--- a/key.go
+++ b/key.go
@@ -146,6 +146,9 @@ DECODEPIECE:
 			key = k
 			if UnifyEnterKeys && key == ctrlKeys['j'] {
 				key = tcell.KeyEnter
+			} else if key == ctrlKeys['h'] {
+				mod ^= tcell.ModCtrl
+				key = tcell.KeyBackspace
 			} else if key < 0x80 {
 				ch = rune(key)
 			}


### PR DESCRIPTION
Revert changes in configuration.go to stop changing ctrl on capture.
SetKey ctrl+h deletes ctrl.